### PR TITLE
Use AsRef<Path> instead of &str for constructors

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -6,7 +6,7 @@
 extern crate zip;
 
 use std::fs;
-use std::path;
+use std::path::{Path, PathBuf};
 use failure::Error;
 
 use std::io::Read;
@@ -15,7 +15,7 @@ use std::io::Read;
 /// files in the zip archive.
 pub struct EpubArchive {
     zip: zip::ZipArchive<fs::File>,
-    pub path: String,
+    pub path: PathBuf,
     pub files: Vec<String>,
 }
 
@@ -26,9 +26,9 @@ impl EpubArchive {
     ///
     /// Returns an error if the zip is broken or if the file doesn't
     /// exists.
-    pub fn new(path: &str) -> Result<EpubArchive, Error> {
-        let fname = path::Path::new(path);
-        let file = fs::File::open(&fname)?;
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubArchive, Error> {
+        let path = path.as_ref();
+        let file = fs::File::open(path)?;
 
         let mut zip = zip::ZipArchive::new(file)?;
         let mut files = vec![];
@@ -40,7 +40,7 @@ impl EpubArchive {
 
         Ok(EpubArchive {
             zip: zip,
-            path: String::from(path),
+            path: path.to_path_buf(),
             files: files,
         })
     }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -50,9 +50,10 @@ impl EpubArchive {
     /// # Errors
     ///
     /// Returns an error if the name doesn't exists in the zip archive.
-    pub fn get_entry(&mut self, name: &str) -> Result<Vec<u8>, Error> {
+    pub fn get_entry<P: AsRef<Path>>(&mut self, name: P) -> Result<Vec<u8>, Error> {
         let mut entry: Vec<u8> = vec![];
-        let mut zipfile = self.zip.by_name(name)?;
+        let name = name.as_ref().display().to_string();
+        let mut zipfile = self.zip.by_name(&name)?;
         zipfile.read_to_end(&mut entry)?;
         Ok(entry)
     }
@@ -62,11 +63,9 @@ impl EpubArchive {
     /// # Errors
     ///
     /// Returns an error if the name doesn't exists in the zip archive.
-    pub fn get_entry_as_str(&mut self, name: &str) -> Result<String, Error> {
-        let mut entry = String::new();
-        let mut zipfile = self.zip.by_name(name)?;
-        zipfile.read_to_string(&mut entry)?;
-        Ok(entry)
+    pub fn get_entry_as_str<P: AsRef<Path>>(&mut self, name: P) -> Result<String, Error> {
+        let content = self.get_entry(name)?;
+        String::from_utf8(content).map_err(Error::from)
     }
 
     /// Returns the content of container file "META-INF/container.xml".

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -350,10 +350,11 @@ impl EpubDoc {
     ///
     /// ```
     /// # use epub::doc::EpubDoc;
+    /// # use std::path::Path;
     /// # let doc = EpubDoc::new("test.epub");
     /// # let doc = doc.unwrap();
     /// let p = doc.get_current_path();
-    /// assert_eq!("OEBPS/Text/titlepage.xhtml", p.unwrap());
+    /// assert_eq!(Path::new("OEBPS/Text/titlepage.xhtml"), p.unwrap());
     /// ```
     pub fn get_current_path(&self) -> Result<PathBuf, Error> {
         let current_id = self.get_current_id()?;

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -71,7 +71,7 @@ impl EpubDoc {
     ///
     /// Returns an error if the epub is broken or if the file doesn't
     /// exists.
-    pub fn new(path: &str) -> Result<EpubDoc, Error> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubDoc, Error> {
         let mut archive = EpubArchive::new(path)?;
         let spine: Vec<String> = vec![];
         let resources: HashMap<String, (String, String)> = HashMap::new();

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -598,5 +598,5 @@ fn build_epub_uri<P: AsRef<Path>>(path: P, append: &str) -> String {
         };
     }
 
-    format!("epub://{}", path.display())
+    format!("epub://{}", cpath.display())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,12 @@
 //!
 //! ```
 //! # use epub::doc::EpubDoc;
+//! # use std::path::Path;
 //! # let doc = EpubDoc::new("test.epub");
 //! # let doc = doc.unwrap();
 //! assert_eq!(21, doc.resources.len());
 //! let tpage = doc.resources.get("titlepage.xhtml");
-//! assert_eq!(tpage.unwrap().0, "OEBPS/Text/titlepage.xhtml");
+//! assert_eq!(tpage.unwrap().0, Path::new("OEBPS/Text/titlepage.xhtml"));
 //! assert_eq!(tpage.unwrap().1, "application/xhtml+xml");
 //! ```
 //!

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -9,9 +9,8 @@ fn archive_open() {
     let archive = EpubArchive::new("test.epub");
     assert!(archive.is_ok());
     let archive = archive.unwrap();
-    assert_eq!("test.epub", archive.path);
+    assert_eq!("test.epub", archive.path.display().to_string());
     assert_eq!(30, archive.files.len());
-
 }
 
 #[test]

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -1,19 +1,20 @@
 extern crate epub;
 
 use epub::doc::EpubDoc;
+use std::path::Path;
 
 #[test]
 fn doc_open() {
     let doc = EpubDoc::new("test.epub");
     assert!(doc.is_ok());
     let doc = doc.unwrap();
-    assert_eq!("OEBPS/", doc.root_base);
-    assert_eq!("OEBPS/content.opf", doc.root_file);
+    assert_eq!(Path::new("OEBPS"), doc.root_base);
+    assert_eq!(Path::new("OEBPS/content.opf"), doc.root_file);
 
     assert_eq!(21, doc.resources.len());
     {
         let tpage = doc.resources.get("titlepage.xhtml");
-        assert_eq!(tpage.unwrap().0, "OEBPS/Text/titlepage.xhtml");
+        assert_eq!(tpage.unwrap().0, Path::new("OEBPS/Text/titlepage.xhtml"));
     }
 
     {

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -19,10 +19,9 @@ fn read_doc() {
     {
         println!("resources:\n");
         for (k, v) in doc.resources.iter() {
-            println!("{}: {}\n * {}\n", k, v.1, v.0);
+            println!("{}: {}\n * {}\n", k, v.1, v.0.display());
         }
         println!("");
-
     }
 
     while let Ok(_) = doc.go_next() {
@@ -30,7 +29,7 @@ fn read_doc() {
         let current = doc.get_current_str();
         match current {
             Ok(v) => println!("Value {:?}\n", v),
-            Err(e) => println!("Text Err {:?}\n", e)
+            Err(e) => println!("Text Err {:?}\n", e),
         }
     }
 }


### PR DESCRIPTION
It's more idiomatic to use `P: AsRef<Path>` instead of a `&str` when constructing a file or recording a filesystem path. That way you can accept more types of inputs (e.g. `PathBuf` and `String`) and aren't constraining the user more than you need to.