### PR TITLE
meta element with property attribute

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -600,6 +600,18 @@ impl EpubDoc {
                     } else {
                         self.metadata.insert(k, vec![v]);
                     }
+                } else if let Ok(k) = item.get_attr("property") {
+                    let v = match item.text {
+                        Some(ref x) => x.to_string(),
+                        None => String::from(""),
+                    };
+                    if self.metadata.contains_key(&k) {
+                        if let Some(arr) = self.metadata.get_mut(&k) {
+                            arr.push(v);
+                        }
+                    } else {
+                        self.metadata.insert(k, vec![v]);
+                    }
                 }
             } else {
                 let k = &item.name.local_name;

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -31,6 +31,11 @@ fn doc_open() {
         let cover = doc.get_cover_id();
         assert_eq!(cover.unwrap(), "portada.png");
     }
+
+    {
+        let modified = doc.mdata("dcterms:modified");
+        assert_eq!(modified.unwrap(), "2015-08-10T18:12:03Z");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Hi,

In EPUB spec, some `meta` elements with `property` attribute are used such as:

```xml
<meta property="dcterms:modified">2016-02-29T12:34:56Z</meta>
```
(https://www.w3.org/publishing/epub3/epub-packages.html#example-14)

I wrote a patch to handle with those `meta` elements. Could you consider this patch?

Thanks.