### PR TITLE
Unique Identifier and Release Identifier

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -80,6 +80,9 @@ pub struct EpubDoc {
 
     /// Custom css list to inject in every xhtml file
     pub extra_css: Vec<String>,
+
+    /// unique identifier
+    pub unique_identifier: Option<String>,
 }
 
 impl EpubDoc {
@@ -120,6 +123,7 @@ impl EpubDoc {
             root_base: base_path.to_path_buf(),
             current: 0,
             extra_css: vec![],
+            unique_identifier: None,
         };
 
         doc.fill_resources()?;
@@ -563,6 +567,8 @@ impl EpubDoc {
         let xml = xmlutils::XMLReader::new(container.as_slice());
         let root = xml.parse_xml()?;
 
+        let unique_identifier_id = &root.borrow().get_attr("unique-identifier").ok();
+
         // resources from manifest
         let manifest = root.borrow().find("manifest")?;
         for r in manifest.borrow().childs.iter() {
@@ -619,6 +625,13 @@ impl EpubDoc {
                     Some(ref x) => x.to_string(),
                     None => String::from(""),
                 };
+                if k == "identifier" && self.unique_identifier.is_none() && unique_identifier_id.is_some() {
+                    if let Ok(id) = item.get_attr("id") {
+                        if &id == unique_identifier_id.as_ref().unwrap() {
+                            self.unique_identifier = Some(v.to_string());
+                        }
+                    }
+                }
                 if self.metadata.contains_key(k) {
                     if let Some(arr) = self.metadata.get_mut(k) {
                         arr.push(v);

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -204,6 +204,15 @@ impl EpubDoc {
         Ok(cover_data)
     }
 
+    /// Returns Release Identifier defined at
+    /// https://www.w3.org/publishing/epub3/epub-packages.html#sec-metadata-elem-identifiers-pid
+    pub fn get_release_identifier(&self) -> Option<String> {
+        match (self.unique_identifier.as_ref(), self.mdata("dcterms:modified")) {
+            (Some(unique_identifier), Some(modified)) => Some(format!("{}@{}", unique_identifier, modified)),
+            _ => None,
+        }
+    }
+
     /// Returns the resource content by full path in the epub archive
     ///
     /// # Errors

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -41,6 +41,11 @@ fn doc_open() {
         let modified = doc.mdata("dcterms:modified");
         assert_eq!(modified.unwrap(), "2015-08-10T18:12:03Z");
     }
+
+    {
+        let release_identifier = doc.get_release_identifier();
+        assert_eq!(release_identifier.unwrap(), "urn:uuid:09132750-3601-4d19-b3a4-55fdf8639849@2015-08-10T18:12:03Z");
+    }
 }
 
 #[test]

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -23,6 +23,11 @@ fn doc_open() {
     }
 
     {
+        let unique_identifier = doc.unique_identifier.clone();
+        assert_eq!(unique_identifier.unwrap(), "urn:uuid:09132750-3601-4d19-b3a4-55fdf8639849");
+    }
+
+    {
         let title = doc.mdata("title");
         assert_eq!(title.unwrap(), "Todo es mío");
     }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -8,6 +8,7 @@ fn doc_open() {
     let doc = EpubDoc::new("test.epub");
     assert!(doc.is_ok());
     let doc = doc.unwrap();
+    let doc2 = EpubDoc::new("tests/docs/Metamorphosis-jackson.epub").unwrap();
     assert_eq!(Path::new("OEBPS"), doc.root_base);
     assert_eq!(Path::new("OEBPS/content.opf"), doc.root_file);
 
@@ -45,6 +46,16 @@ fn doc_open() {
     {
         let release_identifier = doc.get_release_identifier();
         assert_eq!(release_identifier.unwrap(), "urn:uuid:09132750-3601-4d19-b3a4-55fdf8639849@2015-08-10T18:12:03Z");
+    }
+
+    {
+        let unique_identifier = doc2.unique_identifier.clone();
+        assert_eq!("http://metamorphosiskafka.pressbooks.com", unique_identifier.unwrap());
+    }
+
+    {
+        let release_identifier = doc2.get_release_identifier();
+        assert_eq!(None, release_identifier);
     }
 }
 


### PR DESCRIPTION
Hello, again.

I added a field and a method for Unique Identifier and Release Identifier(https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-metadata-identifiers). Can you review it?

Especially, I think `unique_identifier` fields should be `Option<&str>` that refers an item of `mdata("identifier")`, but I couldn't implement so because I'm a newcomer to Rust. If you know how to do, please tell me and I will fix it.

Thank you!