### PR TITLE
Simplify EpubDoc::new(), EpubArchive::new()

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -28,22 +28,7 @@ impl EpubArchive<File> {
     /// Returns an error if the zip is broken or if the file doesn't
     /// exists.
     pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubArchive<File>, Error> {
-        let path = path.as_ref();
-        let file = File::open(path)?;
-
-        let mut zip = zip::ZipArchive::new(file)?;
-        let mut files = vec![];
-
-        for i in 0..(zip.len()) {
-            let file = zip.by_index(i)?;
-            files.push(String::from(file.name()));
-        }
-
-        Ok(EpubArchive {
-            zip,
-            path: path.to_path_buf(),
-            files,
-        })
+        EpubArchive::from_reader(File::open(path)?)
     }
 }
 

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -107,30 +107,7 @@ impl EpubDoc<File> {
     /// Returns an error if the epub is broken or if the file doesn't
     /// exists.
     pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubDoc<File>, Error> {
-        let mut archive = EpubArchive::new(path)?;
-        let spine: Vec<String> = vec![];
-        let resources = HashMap::new();
-
-        let container = archive.get_container_file()?;
-        let root_file = get_root_file(container)?;
-        let base_path = root_file.parent().expect("All files have a parent");
-
-        let mut doc = EpubDoc {
-            archive,
-            spine,
-            toc: vec![],
-            resources,
-            metadata: HashMap::new(),
-            root_file: root_file.clone(),
-            root_base: base_path.to_path_buf(),
-            current: 0,
-            extra_css: vec![],
-            unique_identifier: None,
-        };
-
-        doc.fill_resources()?;
-
-        Ok(doc)
+        EpubDoc::from_reader(File::open(path)?)
     }
 }
 


### PR DESCRIPTION
You can reduce a bit of the code duplication for EpubDoc::new, EpubArchive::new by using opening the file and then immediately calling EpubDoc::from_reader / EpubArchive::from_reader.

As a side note, while using this library, I noticed that using BufReader sped up reading ebooks by ~1.5-2x (makes a noticable difference when reading 100+ epubs). Given that the default method is to do unbuffered reads, and it isn't immediately obvious that buffered reading would have such a significant effect on performance, I think it would be nice if this possibility was mentioned in the documentation (or if the code itself used BufReader by default).

Additionally, I was wondering if you had any plans to push a new version of the crate to crates.io - the current version is out of date by several months, and doesn't provide from_reader, which is a really useful interface.