### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,37 @@
+name: Rust
+
+on:
+  push:
+    paths:
+    - "**/*.rs"
+    - "**/*.yml"
+    - "Cargo.toml"
+    - "**/*.epub"
+  pull_request:
+    paths:
+    - "**/*.rs"
+    - "**/*.yml"
+    - "Cargo.toml"
+    - "**/*.epub"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        rust: [stable, 1.31.0]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        override: true
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
It might be a good idea to have continuous integration set up to ensure that this project compiles on all platforms.

I set an arbitrary minimum version - this can be changed, since I wasn't too sure what would be appropriate for this crate.