### PR TITLE
Bump minimum Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        rust: [stable, 1.34.0]
+        rust: [stable, 1.38.0]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        rust: [stable, 1.38.0]
+        rust: [stable, 1.40.0]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        rust: [stable, 1.31.0]
+        rust: [stable, 1.34.0]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ Rust library to support the reading of epub files.
 * EpubDoc Doc: https://danigm.github.io/epub-rs-doc/epub/doc/struct.EpubDoc.html
 * Crate: https://crates.io/crates/epub
 
+# Install
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+epub = "1.2.2"
+```
+
+The minimum supported Rust version is 1.40.0.


### PR DESCRIPTION
It seems that this crate requires at least Rust 1.40.0 for everything. I think it would be helpful to note this in the README.

There also seems to be a test failure which occurs on Windows - I'd imagine it has something to do with text encoding or path formatting on Windows?
