### PR TITLE
Use BufReader by default instead of File

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Error;
 use std::fs::File;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use std::io::{Read, Seek};
@@ -17,16 +18,17 @@ pub struct EpubArchive<R: Read + Seek> {
     pub files: Vec<String>,
 }
 
-impl EpubArchive<File> {
+impl EpubArchive<BufReader<File>> {
     /// Opens the epub file in `path`.
     ///
     /// # Errors
     ///
     /// Returns an error if the zip is broken or if the file doesn't
     /// exists.
-    pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubArchive<File>, Error> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubArchive<BufReader<File>>, Error> {
         let path = path.as_ref();
-        let mut archive = EpubArchive::from_reader(File::open(path)?)?;
+        let file = File::open(path)?;
+        let mut archive = EpubArchive::from_reader(BufReader::new(file))?;
         archive.path = path.to_path_buf();
         Ok(archive)
     }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Error};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::BufReader;
 use std::io::{Read, Seek};
 use std::path::{Component, Path, PathBuf};
 
@@ -86,7 +87,7 @@ pub struct EpubDoc<R: Read + Seek> {
     pub unique_identifier: Option<String>,
 }
 
-impl EpubDoc<File> {
+impl EpubDoc<BufReader<File>> {
     /// Opens the epub file in `path`.
     ///
     /// Initialize some internal variables to be able to access to the epub
@@ -105,9 +106,10 @@ impl EpubDoc<File> {
     ///
     /// Returns an error if the epub is broken or if the file doesn't
     /// exists.
-    pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubDoc<File>, Error> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<EpubDoc<BufReader<File>>, Error> {
         let path = path.as_ref();
-        let mut doc = EpubDoc::from_reader(File::open(path)?)?;
+        let file = File::open(path)?;
+        let mut doc = EpubDoc::from_reader(BufReader::new(file))?;
         doc.archive.path = path.to_path_buf();
         Ok(doc)
     }


### PR DESCRIPTION
It looks like using BufReader by default is a lot faster than just File,
so it's better to use this method by default.

https://github.com/danigm/epub-rs/pull/17#issue-522254334