### PR TITLE
Don't use default features of zip crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ edition = "2018"
 [dependencies]
 regex = "1.4.2"
 xml-rs = "0.8.3"
-zip = "0.5.8"
+zip = { version = "0.5.13", default-features = false, features = ["deflate"]}
 percent-encoding = "2.1.0"
 anyhow = "1.0.34"


### PR DESCRIPTION
Hi!
This PR allow use epub-rs for WASM target (already works for me)

On spec ZIP containers must be uncompressed or `deflate`, but I'm not sure...
https://www.w3.org/publishing/epub3/epub-ocf.html#sec-zip-container-zipreqs

May be pass `zip/deflate` or `zip/bzip2` to zip dependency is would be more universal solution

Sorry, for my poor English.
P.S. Feel free to close this PR without merging it
