### PR TITLE
Find the cover id either in the metadata or in the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["epub", "ebook"]
 license = "GPL-3.0"
 name = "epub"
 repository = "https://github.com/danigm/epub-rs.git"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2018"
 
 [dependencies]

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -36,7 +36,7 @@ fn doc_open() {
 
     {
         let cover = doc.get_cover_id();
-        assert_eq!(cover, "portada.png");
+        assert_eq!(cover, Some("portada.png".into()));
     }
 
     {


### PR DESCRIPTION
This PR introduces a breaking change in the API: the get_cover_id method now returns an Option<String>

Closes #35