### PR TITLE
fix: panic for empty or otherwise too small inner file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.swp
+.DS_Store

--- a/src/xmlutils.rs
+++ b/src/xmlutils.rs
@@ -32,6 +32,8 @@ pub enum XMLError {
     InvalidState,
     #[error("No XML Elements Found")]
     NoElements,
+    #[error("XML content is empty")]
+    NoContent,
 }
 
 pub struct XMLReader<'a> {
@@ -40,6 +42,11 @@ pub struct XMLReader<'a> {
 
 impl<'a> XMLReader<'a> {
     pub fn parse(content: &[u8]) -> Result<RefCell<XMLNode>, XMLError> {
+        // The operations below require at least 4 bytes to not panic
+        if content.is_empty() || content.len() < 4 {
+            return Err(XMLError::NoContent);
+        }
+
         let content_str;
         //If there is a UTF-8 BOM marker, ignore it
         let content_slice = if content[0..3] == [0xefu8, 0xbbu8, 0xbfu8] {


### PR DESCRIPTION
I've added a check before the beginning of `XMLReader::parse` to ensure the container content has enough byte content to avoid a panic, something that was reported originally in https://github.com/stumpapp/stump/issues/259

I originally added the faulty/corrupt file and an additional test, but realized I doubt the license for it is permissive (e.g. creative commons or public domain) to put directly in the repo so left it out here. While there is definitely a fault in the file itself, I figure a bit of added safety here doesn't hurt.