### PR TITLE
Adding mock constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ xml-rs = "0.8.20"
 percent-encoding = "2.3.1"
 thiserror = "1.0.59"
 
+[features]
+mock = []
+
 [dependencies.zip]
 version = "1.1.3"
 default-features = false

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -113,6 +113,33 @@ pub struct EpubDoc<R: Read + Seek> {
     pub cover_id: Option<String>,
 }
 
+/// A EpubDoc used for testing purposes
+#[cfg(feature = "mock")]
+impl EpubDoc<std::io::Cursor<Vec<u8>>> {
+    pub fn mock() -> Result<Self, DocError> {
+        // binary for empty zip file so that archive can be created
+        let data: Vec<u8> = vec![
+            0x50, 0x4b, 0x05, 0x06, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
+            00, 00,
+        ];
+
+        let archive = EpubArchive::from_reader(std::io::Cursor::new(data))?;
+        Ok(Self {
+            archive,
+            spine: vec![],
+            toc: vec![],
+            resources: HashMap::new(),
+            metadata: HashMap::new(),
+            root_file: PathBuf::new(),
+            root_base: PathBuf::new(),
+            current: 0,
+            extra_css: vec![],
+            unique_identifier: None,
+            cover_id: None,
+        })
+    }
+}
+
 impl EpubDoc<BufReader<File>> {
     /// Opens the epub file in `path`.
     ///

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -2,6 +2,13 @@ use epub::doc::EpubDoc;
 use std::path::Path;
 
 #[test]
+#[cfg(feature = "mock")]
+fn doc_mock() {
+    let doc = EpubDoc::mock();
+    assert!(doc.is_ok());
+}
+
+#[test]
 fn doc_open() {
     let doc = EpubDoc::new("test.epub");
     assert!(doc.is_ok());


### PR DESCRIPTION
This adds a mock constructor hidden behind a feature flag.

When testing with other applications, it is sometimes useful to be able to create an epub doc inline in the unit test without polluting the git repo with a bunch of test zip files.