### PR TITLE
Add field EpubDoc::toc_title

### DIFF
--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -89,6 +89,15 @@ fn toc_test() {
 }
 
 #[test]
+fn toc_title_test() {
+    let doc = EpubDoc::new("test.epub");
+    assert!(doc.is_ok());
+    let doc = doc.unwrap();
+
+    assert!(doc.toc_title == "Todo es mío");
+}
+
+#[test]
 fn version_test() {
     let doc = EpubDoc::new("test.epub");
     assert!(doc.is_ok());


### PR DESCRIPTION
Its value is found in <docTitle> in toc.ncx.

---

Ref:
- NCX `docTitle`: https://github.com/oxygenxml/Daisy/blob/f9b261f94f3ebb603b9dabbbcf4284bbe27e474e/daisy/schemas/dtd/ncx-2005-1.dtd#L109
- EPUB 3 navigation document title `nav > h1-h6`: https://www.w3.org/TR/epub-33/#sec-nav-def-model

I considered two alternative changes both of which incompatible with the existing `EpubDoc::toc` though having their own upsides:
1. Make `toc` a root `NavPoint` which has toc title in its label and all first-level `NavPoint`s in its children.
2. Make `toc` a `struct { title: String, nav_map: Vec<NavPoint> }`

`docAuthor` is probably not very useful so not considered at the moment.
`docTitle` is useful, which is further proved by EPUB 3 navigation document including a heading in its `nav`.