### PR TITLE
ResourceItem, EpubDoc::get_cover_id, EpubDoc::get_nav_id, EpubDoc::get_title

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -285,10 +285,18 @@ impl<R: Read + Seek> EpubDoc<R> {
     /// # use epub::doc::EpubDoc;
     /// # let doc = EpubDoc::new("test.epub");
     /// # let doc = doc.unwrap();
-    /// let title = doc.mdata("title");
-    /// assert_eq!(title.unwrap().value, "Todo es mío");
+    /// let language = doc.mdata("language");
+    /// assert_eq!(language.unwrap().value, "es");
     pub fn mdata(&self, property: &str) -> Option<&MetadataItem> {
         self.metadata.iter().find(|data| data.property == property)
+    }
+
+    /// Returns the title.
+    ///
+    /// An EPUB file may provide multiple titles. This method only returns the
+    /// primary one. Access `metadata` directly to gain more control.
+    pub fn get_title(&self) -> Option<String> {
+        self.mdata("title").map(|item| item.value.clone())
     }
 
     /// Returns the id of the epub cover.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@
 //! # use epub::doc::EpubDoc;
 //! # let doc = EpubDoc::new("test.epub");
 //! # let doc = doc.unwrap();
-//! let title = doc.mdata("title");
-//! assert_eq!(title.unwrap().value, "Todo es mío");
+//! let language = doc.mdata("language");
+//! assert_eq!(language.unwrap().value, "es");
 //! ```
 //!
 //! ## Accessing resources

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@
 //! # let doc = doc.unwrap();
 //! assert_eq!(23, doc.resources.len());
 //! let tpage = doc.resources.get("titlepage.xhtml");
-//! assert_eq!(tpage.unwrap().0, Path::new("OEBPS/Text/titlepage.xhtml"));
-//! assert_eq!(tpage.unwrap().1, "application/xhtml+xml");
+//! assert_eq!(tpage.unwrap().path, Path::new("OEBPS/Text/titlepage.xhtml"));
+//! assert_eq!(tpage.unwrap().mime, "application/xhtml+xml");
 //! ```
 //!
 //! ## Navigating using the spine

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -22,7 +22,7 @@ fn doc_open() {
     assert_eq!(23, doc.resources.len());
     {
         let tpage = doc.resources.get("titlepage.xhtml");
-        assert_eq!(tpage.unwrap().0, Path::new("OEBPS/Text/titlepage.xhtml"));
+        assert_eq!(tpage.unwrap().path, Path::new("OEBPS/Text/titlepage.xhtml"));
     }
 
     {

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -107,6 +107,18 @@ fn doc_open_epub3() {
         assert_eq!(ident_type.scheme, Some("onix:codelist5".to_string()));
         assert_eq!(ident_type.value, "15");
     }
+
+    {
+        // Test cover
+        let cover_mime = doc.get_cover_id().and_then(|id| doc.get_resource_mime(&id));
+        assert_eq!(cover_mime, Some("image/jpeg".to_string()));
+    }
+
+    {
+        // Test nav
+        let nav_mime = doc.get_nav_id().and_then(|id| doc.get_resource_mime(&id));
+        assert_eq!(nav_mime, Some("application/xhtml+xml".to_string()));
+    }
 }
 
 #[test]

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -45,8 +45,8 @@ fn doc_open() {
     }
 
     {
-        let title = doc.mdata("title");
-        assert_eq!(title.unwrap().value, "Todo es mío");
+        let title = doc.get_title().unwrap_or_default();
+        assert_eq!(title, "Todo es mío");
     }
 
     {

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -17,7 +17,7 @@ fn read_doc() {
     {
         println!("resources:\n");
         for (k, v) in doc.resources.iter() {
-            println!("{}: {}\n * {}\n", k, v.1, v.0.display());
+            println!("{}: {}\n * {}\n", k, v.mime, v.path.display());
         }
         println!();
     }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -7,8 +7,8 @@ fn read_doc() {
     assert!(doc.is_ok());
     let mut doc = doc.unwrap();
 
-    if let Some(title) = doc.mdata("title") {
-        println!("Book title: {}", title.value);
+    if let Some(title) = doc.get_title() {
+        println!("Book title: {}", title);
     } else {
         println!("Book title not found");
     }


### PR DESCRIPTION
Three commits are
1. Use struct `ResourceItem` to replace tuple and stores (manifest) item properties. This enables the next point.
2. Modified `get_cover_id` and added `get_nav_id`. Looking for the cover's ID in the method instead of when initializing (and storing in a field) is kind of a conversion to a lazy approach. It doesn't matter much but my real motivation was to delete this side-effect of setting `self.cover_id` from the metadata construction procedure.
3. (Not closely related to the previous two.) The change of `metadata`'s type makes getting the title (into a string) need more typing. Considering that is perhaps a very common task, `get_title` is provided conveniently.