### PR TITLE
Fix: Populate `NavPoint`s even if `playOrder` not present

### DIFF
--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -131,7 +131,7 @@ fn toc_test() {
     for nav in doc.toc.iter() {
         let chapter = doc.resource_uri_to_chapter(&nav.content);
         assert!(chapter.is_some());
-        assert_eq!(nav.play_order, chapter.unwrap());
+        assert_eq!(nav.play_order.unwrap(), chapter.unwrap());
     }
 }
 
@@ -142,6 +142,24 @@ fn toc_title_test() {
     let doc = doc.unwrap();
 
     assert!(doc.toc_title == "Todo es mío");
+}
+
+#[test]
+fn test_toc_play_order() {
+    let doc = EpubDoc::new("test.epub");
+    assert!(doc.is_ok());
+    let doc = doc.unwrap();
+
+    assert!(!doc.toc.is_empty());
+    let mut previous_order = None;
+    for nav in doc.toc.iter() {
+        nav.play_order.map(|order| {
+            if let Some(prev) = previous_order {
+                assert!(prev < order, "Play order is not increasing");
+            }
+            previous_order = Some(order);
+        });
+    }
 }
 
 #[test]


### PR DESCRIPTION
Hey there! 👋 

Sorry for the random PR! This proposed change relates to a bug reported for [Stump](https://github.com/stumpapp/stump/issues/689) where a user reported an empty toc for some of their books. I believe I narrowed it down to `epub-rs` only including `NavPoint`s which have a defined `playOrder`.

I'm happy to discuss and iterate on this change if it isn't within your preferred scope for the library. I also want to note that it _could_ be possible to add `id` to the `NavPoint` as a fallback for sorting if desired, but didn't implement any of that since it would kinda be inconsistent for the `Ord` implementation in the scenario where one `NavPoint` has a `play_order` but another has `id`.