### PR TITLE
Fix naming convention from pages to chapters

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -657,10 +657,21 @@ impl<R: Read + Seek> EpubDoc<R> {
         self.spine.len()
     }
 
+    #[deprecated(note="please use `get_num_chapters` instead")]
+    pub fn get_num_pages(&self) -> usize {
+        self.get_num_chapters()
+    }
+
     /// Returns the current chapter number, starting from 0
     pub fn get_current_chapter(&self) -> usize {
         self.current
     }
+
+    #[deprecated(note="please use `get_current_chapter` instead")]
+    pub fn get_current_page(&self) -> usize {
+        self.get_current_chapter()
+    }
+
 
     /// Changes the current chapter
     ///
@@ -686,6 +697,12 @@ impl<R: Read + Seek> EpubDoc<R> {
             true
         }
     }
+
+    #[deprecated(note="please use `set_current_chapter` instead")]
+    pub fn set_current_page(&mut self, n: usize) -> bool {
+        self.set_current_chapter(n)
+    }
+
 
     /// This will inject arbitrary css into every queried html page 
     /// [`Self::get_current_with_epub_uris`]

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -651,18 +651,18 @@ impl<R: Read + Seek> EpubDoc<R> {
     /// # use epub::doc::EpubDoc;
     /// # let doc = EpubDoc::new("test.epub");
     /// # let mut doc = doc.unwrap();
-    /// assert_eq!(17, doc.get_num_pages());
+    /// assert_eq!(17, doc.get_num_chapters());
     /// ```
-    pub fn get_num_pages(&self) -> usize {
+    pub fn get_num_chapters(&self) -> usize {
         self.spine.len()
     }
 
     /// Returns the current chapter number, starting from 0
-    pub fn get_current_page(&self) -> usize {
+    pub fn get_current_chapter(&self) -> usize {
         self.current
     }
 
-    /// Changes the current page
+    /// Changes the current chapter
     ///
     /// # Examples
     ///
@@ -670,15 +670,15 @@ impl<R: Read + Seek> EpubDoc<R> {
     /// # use epub::doc::EpubDoc;
     /// # let doc = EpubDoc::new("test.epub");
     /// # let mut doc = doc.unwrap();
-    /// assert_eq!(0, doc.get_current_page());
-    /// doc.set_current_page(2);
+    /// assert_eq!(0, doc.get_current_chapter());
+    /// doc.set_current_chapter(2);
     /// assert_eq!("001.xhtml", doc.get_current_id().unwrap());
-    /// assert_eq!(2, doc.get_current_page());
-    /// assert!(!doc.set_current_page(50));
+    /// assert_eq!(2, doc.get_current_chapter());
+    /// assert!(!doc.set_current_chapter(50));
     /// ```
     ///
-    /// Returns [`false`] if the page is out of bounds
-    pub fn set_current_page(&mut self, n: usize) -> bool {
+    /// Returns [`false`] if the chapter is out of bounds
+    pub fn set_current_chapter(&mut self, n: usize) -> bool {
         if n >= self.spine.len() {
             false
         } else {
@@ -687,7 +687,7 @@ impl<R: Read + Seek> EpubDoc<R> {
         }
     }
 
-    /// This will inject this css in every html page getted with
+    /// This will inject arbitrary css into every queried html page 
     /// [`Self::get_current_with_epub_uris`]
     ///
     /// # Examples
@@ -696,7 +696,7 @@ impl<R: Read + Seek> EpubDoc<R> {
     /// # use epub::doc::EpubDoc;
     /// # let doc = EpubDoc::new("test.epub");
     /// # let mut doc = doc.unwrap();
-    /// # let _ = doc.set_current_page(2);
+    /// # let _ = doc.set_current_chapter(2);
     /// let extracss = "body { background-color: black; color: white }";
     /// doc.add_extra_css(extracss);
     /// let current = doc.get_current_with_epub_uris().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! use epub::doc::EpubDoc;
 //! let doc = EpubDoc::new("test.epub");
 //! let mut doc = doc.unwrap();
-//! assert_eq!(0, doc.get_current_page());
+//! assert_eq!(0, doc.get_current_chapter());
 //! assert_eq!("application/xhtml+xml", doc.get_current_mime().unwrap());
 //!
 //! doc.go_next();
@@ -83,13 +83,13 @@
 //! doc.go_prev();
 //! assert_eq!("000.xhtml", doc.get_current_id().unwrap());
 //!
-//! doc.set_current_page(2);
+//! doc.set_current_chapter(2);
 //! assert_eq!("001.xhtml", doc.get_current_id().unwrap());
-//! assert_eq!(2, doc.get_current_page());
-//! assert!(!doc.set_current_page(50));
+//! assert_eq!(2, doc.get_current_chapter());
+//! assert!(!doc.set_current_chapter(50));
 //!
-//! // doc.get_current() will return a Vec<u8> with the current page content
-//! // doc.get_current_str() will return a String with the current page content
+//! // doc.get_current() will return a Vec<u8> with the current chapter content
+//! // doc.get_current_str() will return a String with the current chapter content
 //! ```
 //!
 //! ## Getting the cover

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -12,7 +12,7 @@ fn read_doc() {
     } else {
         println!("Book title not found");
     }
-    println!("Num Pages: {}\n", doc.get_num_pages());
+    println!("Num Pages: {}\n", doc.get_num_chapters());
 
     {
         println!("resources:\n");


### PR DESCRIPTION
Since epubs are divided into chapters, I think the naming convention for *_pages() is wrong.
Pages are a construct based on client sided parameters, such as text size, font, display size etc. and will vary between parameters. 

Other than that great lib!!