### PR TITLE
use ncx file path as base path for toc

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -964,12 +964,7 @@ impl<R: Read + Seek> EpubDoc<R> {
 
     fn fill_toc(&mut self, id: &str) -> Result<(), DocError> {
         let toc_res = self.resources.get(id).ok_or(DocError::InvalidEpub)?; // this should be turned into it's own error type, but
-        let toc_base_path = self.resources.iter().find_map(|(resource_id, resource)| {
-            match id == resource_id {
-                true => resource.path.parent(),
-                false => None,
-            }
-        }).ok_or(DocError::InvalidEpub)?;
+        let toc_base_path = toc_res.path.parent().ok_or(DocError::InvalidEpub)?;
 
         let container = self.archive.get_entry(&toc_res.path)?;
         let root = xmlutils::XMLReader::parse(container.as_slice())?;


### PR DESCRIPTION
Currently, when filling the TOC, this crate uses the EPUB's base path (derived from the OPF's path) to determine the paths of items in the TOC. This works fine when the NCX file is in the same directory as the OPF; but it leads to incorrect TOC-paths when the NCX is in a different directory than the OPF. For example, [this IDPF sample EPUB](https://github.com/IDPF/epub3-samples/releases/download/20230704/sous-le-vent_svg-in-spine.epub) has its NCX in a subfolder relative to the OPF, and accordingly this crate misparses its sole TOC-item's path as `EPUB/../Content/pageNum-9.svg` when it should properly be `EPUB/Navigation/../Content/pageNum-9.svg`.

This PR, then, is a fix for that misparsing. It updates the crate to fill TOC items' paths based on the NCX's base path, rather than the OPF's.

(Even more ideally, we might want to factor out `..`-like elements and have it parse as `EPUB/Content/pageNum-9.svg`. But that's currently harder to implement, since `Path::normalize_lexically` hasn't yet made it out of nightly; thus I restrained this PR to just the more basic fix.)